### PR TITLE
Add IBI Research to related research group list

### DIFF
--- a/pages/related_organizations.qmd
+++ b/pages/related_organizations.qmd
@@ -75,6 +75,7 @@ HTML(
 * [BCBI](https://github.com/bcbi) – Center for Biomedical Informatics at Brown University ([website](https://brown.edu/go/bcbi))
 * [Holy Lab](https://github.com/HolyLab) - Holy Lab at Washington University in St. Louis ([website](http://holylab.wustl.edu/))
 * [InPhyT](https://github.com/InPhyT) - Interdisciplinary Physics Team 
+* [IBI](https://github.com/IBIResearch) - Institute for Biomedical Imaging in Hamburg, Germany ([website](https://www.tuhh.de/ibi))
 
 ## Companies
 


### PR DESCRIPTION
Hello, I hope this is an appropriate way of adding a related research group😄

We are developing and mainting a few Julia packages in several medical imaging domains and JuliaHealth related organization such as JuliaImageRecon and MagneticResonanceImaging. For example we are mainting several packages which form the image reconstruction backbone of KomaMRI with MRIReco.jl and its related subpackages, NFFT..jl and RegularizedLeastSquares.jl